### PR TITLE
migrate: establish redirect to 'bulib/dcgenesis' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # cc220genesis
+
+_note: this repository has moved to [`bulib/dcgenesis`](https://github.com/bulib/dcgenesis)._

--- a/redirect/index.html
+++ b/redirect/index.html
@@ -1,0 +1,10 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>CC-220 Digital Core: Genesis</title>
+    <meta http-equiv="refresh" content="0;URL='https://bulib.github.io/dcgenesis'"/>
+    <meta name="description" content="Original host site for the Digital Humanities project on Genesis, created as part of Boston University coursework. Now moved to BU Libraries' GitHub."/>
+  </head>    
+  <body> 
+    <p>This page has moved to a <a href="https://bulib.github.io/dcgenesis">bulib.github.io/dcgenesis</a>.</p> 
+  </body>  
+</html>   


### PR DESCRIPTION
### Background
- Jira Ticket: [WEB-117](https://bulibrary.atlassian.net/browse/WEB-117)
- this repository has been forked into `bulib/dcgenesis` and is being served at [bulib.github.io/dcgenesis/](https://bulib.github.io/dcgenesis/)
- after this PR is merged, we'll try to archive and deprecate this repository

### Description of Changes
- add a new directory which will automatically forward traffic to the new site